### PR TITLE
Add missing palettes

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -21,8 +21,17 @@ palette: purple # Default palette. Optional. You'll need to clear the browser ca
 # Available palettes. Default to ALL. Empty array means disable.
 # palettes:
 #  - blue
-#  - purple
+#  - blue-gray
 #  - brown
+#  - cyan
+#  - green
+#  - indigo
+#  - orange
+#  - pink
+#  - purple
+#  - red
+#  - teal
+#  - yellow
 
 # color: dark # light, dark or dynamic. Default to dynamic.
 


### PR DESCRIPTION
As far as I can tell there are [thirteen palettes](https://github.com/razonyang/hugo-theme-bootstrap/blob/e5152b86cb9c018337ff880b0b1b65d824ac2efe/assets/main/scss/_palettes.scss#L14-L27) available.

This pull request is just to add these to the available palettes list.