### PR TITLE
Add missing Staticman parameters

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -151,6 +151,23 @@ utterances:
   # Optional values: github-light, github-dark, preferred-color-scheme, github-dark-orange, icy-dark, dark-blue, photon-dark.
   #theme:  
 
+#staticman:
+  #endpoint: https://yourstaticmaninstance # Required, replace with your own Staticman instance.
+  #repo: user/repo # Required
+  #service: github # or gitlab. Default to GitHub.
+  #branch: main # Default to master.
+  #property: comments # Default to comments.
+  #sorting: desc # Default to asc.
+  #reCaptchaKey: "" # The reCaptcha site key.
+  #reCaptchaSecret: "" # The reCaptcha encrypted secret. You'll need to encrypt plain secret via https://yourstaticmaninstance/v3/encrypt/PLAINSECRET.
+  #extraFields: # Extra fields. Available fiedls: url.
+  #  - url
+  #requiredFields: # Extra required fields. Available fields: email and the extra fields.
+  #  - email
+  #  - url
+  #paginate: 5 # Default to 10.
+  #moderation: false # Same as Staticman's moderation.
+
 #giscus:
   # repo: ""
   # repoId: ""


### PR DESCRIPTION
Taken from the exampleSite config [params.toml](https://github.com/razonyang/hugo-theme-bootstrap/blob/d881f6600f26db035ba4bd23af2adb36e8afe1e0/exampleSite/config/_default/params.toml#L143-L155).

