### PR TITLE
Use default branch to deploy to Gitlab Pages and run test on the rest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,8 @@ default:
 test:
   script:
     - hugo --gc --minify
+  rules:
+    - if: $CI_COMMIT_REF_NAME != $CI_DEFAULT_BRANCH
 
 pages:
   script:
@@ -18,3 +20,5 @@ pages:
   artifacts:
     paths:
       - public
+  rules:
+    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH


### PR DESCRIPTION
This way the test/staging branches won't override the site in production.