### PR TITLE
Replace deprecated paginate parameter to pagination.pagerSize

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -8,7 +8,8 @@ defaultContentLanguage: en
 #  - fr
 #  - zh-cn
 #  - zh-tw
-paginate: 10
+pagination:
+  pagerSize: 10
 # paginatePath: page
 enableRobotsTXT: true
 enableEmoji: true


### PR DESCRIPTION
Fix for the following warning:

```text
WARN deprecated: site config key paginate was
deprecated in Hugo v0.128.0 and will be removed in a
future release. Use pagination.pagerSize instead.
```

More information here:

<https://discourse.gohugo.io/t/pagination-deprecated-error/51571>